### PR TITLE
Alter batchlogic to work with small batch

### DIFF
--- a/web/dataselectie/datasets/generic/index.py
+++ b/web/dataselectie/datasets/generic/index.py
@@ -124,9 +124,9 @@ def return_qs_parts(qs, modulo, modulo_value, sequential=False):
     log.debug(f'PART {modulo_value}/{modulo} {qs_count}')
 
     batch_size = 200
-    for i in range(0, qs_count+batch_size, batch_size):
+    for i in range(0, qs_count, batch_size):
 
-        if i > qs_count:
+        if i+batch_size > qs_count:
             qs_ss = qs_s[i:]
         else:
             qs_ss = qs_s[i:i+batch_size]
@@ -134,8 +134,6 @@ def return_qs_parts(qs, modulo, modulo_value, sequential=False):
         log.debug('Batch %4d %4d', i, i + batch_size)
 
         yield qs_ss, i/qs_count
-
-    raise StopIteration
 
 
 class ImportIndexTask(object):


### PR DESCRIPTION
When debugging and testing (locally) with very small datasets (smaller
then the batch-size) indexing threw StopIterationException. This alters
the logic to calculate which parts of the queryset to yield, and removes
the subsequent throwing of the exception when done.