### PR TITLE
Add rows to index for not owned plots

### DIFF
--- a/web/dataselectie/datasets/brk/management/brk_batch_sql.py
+++ b/web/dataselectie/datasets/brk/management/brk_batch_sql.py
@@ -349,6 +349,13 @@ mapselection_sql_commands = [
         st_multi(st_union(geometrie)) as geometrie
         from geo_brk_detail_niet_eigendom_poly_index
         group by 1, 2""",
+    """INSERT INTO geo_brk_detail_niet_eigendom_poly_index (kadastraal_object_id, eigendom_cat, cat_id, geometrie) Select
+        kadastraal_object_id,
+        eigendom_cat,
+        99::INTEGER as cat_id,
+        st_multi(st_union(geometrie)) as geometrie
+        from geo_brk_detail_niet_eigendom_poly_index
+        group by 1, 2""",
 
     #   Aggregated table for geoselection api
     #       Land plots for aggregated registry-objects


### PR DESCRIPTION
After previous changes the set of wildcard owner types was necessary in
the index of not owned plots. It has been added.