### PR TITLE
Fix import by adding primary key to brk_kadastraalobject

### DIFF
--- a/web/dataselectie/datasets/bag/migrations/bag_sql_constraints.sql
+++ b/web/dataselectie/datasets/bag/migrations/bag_sql_constraints.sql
@@ -747,6 +747,8 @@ ALTER TABLE ONLY bag_woonplaats
 
 -- Completed on 2017-10-09 16:42:44 CEST
 
+ALTER TABLE  ONLY brk_kadastraalobject
+    ADD CONSTRAINT brk_kadastraalobject_pkey PRIMARY KEY (id);
 --
 -- PostgreSQL database dump complete
 --


### PR DESCRIPTION
Moet eigenlijk voor alle tabellen, maar ik hoop dat dit de import fixt