### PR TITLE
DP-6827 - Remove condition to select first kadastraal object in 'lijs…

### DIFF
--- a/web/.jenkins-import/docker-compose.yml
+++ b/web/.jenkins-import/docker-compose.yml
@@ -1,10 +1,5 @@
 version: '3.0'
 services:
-  redis:
-    image: redis:alpine
-    ports:
-      - "6379:6379"
-
   elasticsearch:
     image: amsterdam/elasticsearch6
     user: root

--- a/web/.jenkins-import/docker-compose.yml
+++ b/web/.jenkins-import/docker-compose.yml
@@ -23,7 +23,6 @@ services:
     links:
       - elasticsearch:elasticsearch
       - database:database
-      - redis:redis
     environment:
       DJANGO_SETTINGS_MODULE: dataselectie.settings
       DATAPUNT_API_URL:

--- a/web/dataselectie/dataselectie/settings.py
+++ b/web/dataselectie/dataselectie/settings.py
@@ -89,9 +89,6 @@ ELASTIC_INDICES = {
     'DS_BRK_INDEX': 'ds_brk_index'
 }
 
-REDIS_HOST = get_variable('REDIS_HOST_OVERRIDE', 'redis', 'localhost')
-REDIS_PORT = get_variable('REDIS_PORT_OVERRIDE', '6379')
-
 MAX_SEARCH_ITEMS = 10000
 MIN_BAG_NR = 1000
 MIN_HR_NR = 1000

--- a/web/dataselectie/dataselectie/utils.py
+++ b/web/dataselectie/dataselectie/utils.py
@@ -2,7 +2,6 @@
 import re
 
 import os
-import redis
 from typing import Dict
 
 from django.test.runner import DiscoverRunner
@@ -139,12 +138,3 @@ def get_db_settings(
         'db': get_db_variable(
             db=db, varname='database', docker_default=db)
     }
-
-
-def get_redis():
-    try:
-        redis_db = redis.StrictRedis(settings.REDIS_HOST, settings.REDIS_PORT)
-        redis_time = redis_db.time()
-    except redis.exceptions.ConnectionError:
-        redis_db = None
-    return redis_db

--- a/web/dataselectie/datasets/brk/batch.py
+++ b/web/dataselectie/datasets/brk/batch.py
@@ -1,9 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.db.models import Q
 
-from dataselectie import utils
 from datasets.brk import models
 
 from . import documents
@@ -30,18 +28,6 @@ class RebuildDocTaskBRK(index.CreateDocTypeTask):
     index = settings.ELASTIC_INDICES['DS_BRK_INDEX']
     doc_types = BRK_DOC_TYPES
 
-class FlushRedisDbTask():
-    def __init__(self):
-        pass
-
-    def execute(self):
-        redis = utils.get_redis()
-        if redis:
-            redis.flushall()
-            log.info("Flushing redis")
-        else:
-            log.warning("Redis not available for flushing")
-
 
 class ReBuildIndexDsBRKJob(object):
     name = "Recreate search-index for all BRK data from elastic"
@@ -51,7 +37,6 @@ class ReBuildIndexDsBRKJob(object):
         return [
             DeleteDsBRKIndexTask(),
             RebuildDocTaskBRK(),
-            FlushRedisDbTask(),
         ]
 
 

--- a/web/dataselectie/datasets/brk/views.py
+++ b/web/dataselectie/datasets/brk/views.py
@@ -269,6 +269,21 @@ class BrkKotSearch(BrkAggBase, TableSearchView):
             raise PermissionDenied("scope BRK/RSN required")
         return super().handle_request(request, *args, **kwargs)
 
+    def filter_data(self, elastic_data, request):
+        """
+        Remove duplicate kadastraal_object_id from object_list
+        """
+        new_object_list = []
+        kot_unique = set()
+        for object in elastic_data['object_list']:
+            kadastraal_object_id = object['kadastraal_object_id']
+            if kadastraal_object_id not in kot_unique:
+                new_object_list.append(object)
+                kot_unique.add(kadastraal_object_id)
+
+        elastic_data['object_list'] = new_object_list
+        return elastic_data
+
     def elastic_query(self, query):
         result = meta_q(query)
         result.update({
@@ -279,13 +294,6 @@ class BrkKotSearch(BrkAggBase, TableSearchView):
                     "eerste_adres",
                 ]
             },
-            "query": {
-                "bool": {
-                    "filter": [
-                        {"term": {"kadastraal_object_index": 0}}
-                    ]
-                }
-            }
         })
         return result
 

--- a/web/requirements-to-freeze.txt
+++ b/web/requirements-to-freeze.txt
@@ -11,5 +11,4 @@ factory-boy
 graypy
 psycopg2-binary
 requests
-redis
 sentry-sdk

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -23,7 +23,6 @@ pycparser==2.19
 PyJWT==1.7.1
 python-dateutil==2.7.5
 pytz==2018.9
-redis==3.0.1
 requests==2.21.0
 sentry-sdk==0.6.6
 six==1.12.0


### PR DESCRIPTION
…t' of kadastrale objecten.

This does not work correctly when extra conditions are added such as  eigenaar_type=Pandeigenaar
All references to kadastraal_object_index are removed, as well as the redis instance to
create these indexes.

Duplicates of kadastrale objects in the 'lijst' of kadastrale objects are now removed with
python code, and not with  elastic search. This means that the total_counts are not correct,
and the pagesizes are not 100 but less.