### PR TITLE
Speed up elasticsearch index rebuilds

### DIFF
--- a/web/dataselectie/datasets/bag/batch.py
+++ b/web/dataselectie/datasets/bag/batch.py
@@ -49,30 +49,11 @@ class IndexDsBagTask(index.ImportIndexTask):
     queryset = (
         models.Nummeraanduiding.objects
         .prefetch_related(
-            # adresseerbaar_object returns:
-            # ligplaats or self.standplaats or self.verblijfsobject
-            'ligplaats',
-            'ligplaats__buurt',
-            'ligplaats__buurt__buurtcombinatie',
-            'ligplaats__buurt__stadsdeel',
-            'ligplaats___gebiedsgerichtwerken',
-            'ligplaats___grootstedelijkgebied',
-            'standplaats',
-            'standplaats__buurt',
-            'standplaats__buurt__buurtcombinatie',
-            'standplaats__buurt__stadsdeel',
-            'standplaats___gebiedsgerichtwerken',
-            'standplaats___grootstedelijkgebied',
-            'verblijfsobject',
-            'verblijfsobject__buurt',
-            'verblijfsobject__buurt__buurtcombinatie',
-            'verblijfsobject__buurt__stadsdeel',
-            'verblijfsobject__panden',
-            'verblijfsobject__panden__bouwblok',
-            'verblijfsobject___gebiedsgerichtwerken',
-            'verblijfsobject___grootstedelijkgebied',
             'openbare_ruimte',
             'openbare_ruimte__woonplaats',
+            *models.prefetch_adresseerbaar_objects(),
+            'verblijfsobject__panden',
+            'verblijfsobject__panden__bouwblok',
         )
     )
 

--- a/web/dataselectie/datasets/bag/batch.py
+++ b/web/dataselectie/datasets/bag/batch.py
@@ -46,11 +46,35 @@ class IndexDsBagTask(index.ImportIndexTask):
     name = "index bag data"
     index = settings.ELASTIC_INDICES['DS_BAG_INDEX']
 
-    queryset = models.Nummeraanduiding.objects.\
-        prefetch_related('verblijfsobject').\
-        prefetch_related('standplaats').\
-        prefetch_related('ligplaats').\
-        prefetch_related('openbare_ruimte')
+    queryset = (
+        models.Nummeraanduiding.objects
+        .prefetch_related(
+            # adresseerbaar_object returns:
+            # ligplaats or self.standplaats or self.verblijfsobject
+            'ligplaats',
+            'ligplaats__buurt',
+            'ligplaats__buurt__buurtcombinatie',
+            'ligplaats__buurt__stadsdeel',
+            'ligplaats___gebiedsgerichtwerken',
+            'ligplaats___grootstedelijkgebied',
+            'standplaats',
+            'standplaats__buurt',
+            'standplaats__buurt__buurtcombinatie',
+            'standplaats__buurt__stadsdeel',
+            'standplaats___gebiedsgerichtwerken',
+            'standplaats___grootstedelijkgebied',
+            'verblijfsobject',
+            'verblijfsobject__buurt',
+            'verblijfsobject__buurt__buurtcombinatie',
+            'verblijfsobject__buurt__stadsdeel',
+            'verblijfsobject__panden',
+            'verblijfsobject__panden__bouwblok',
+            'verblijfsobject___gebiedsgerichtwerken',
+            'verblijfsobject___grootstedelijkgebied',
+            'openbare_ruimte',
+            'openbare_ruimte__woonplaats',
+        )
+    )
 
     def convert(self, obj):
         return documents.doc_from_nummeraanduiding(obj)

--- a/web/dataselectie/datasets/hr/models.py
+++ b/web/dataselectie/datasets/hr/models.py
@@ -10,10 +10,23 @@ class DataSelectie(models.Model):
         unique=True,
     )
 
-    bag_numid = models.CharField(
-        max_length=16, db_index=True, blank=True, null=True)
+    nummeraanduiding = models.ForeignKey(
+        'bag.Nummeraanduiding',
+        to_field='landelijk_id',
+        db_column='bag_numid',
+        on_delete=models.DO_NOTHING,
+        blank=True, null=True,
+    )
 
     api_json = JSONField()
 
     class Meta(object):
         managed = False
+
+    @property
+    def bag_numid(self):
+        """
+        The actual DB column is named "bag_numid".
+        Django provides access through it via the _id field.
+        """
+        return self.nummeraanduiding_id

--- a/web/dataselectie/datasets/hr/tests/factories.py
+++ b/web/dataselectie/datasets/hr/tests/factories.py
@@ -59,7 +59,7 @@ def dataselectie_hr_factory(nummeraanduiding_obj, from_nr, to_nr):
         DataSelectie.objects.get_or_create(
             uid=uid,
             api_json=json,
-            bag_numid=nummeraanduiding_obj.landelijk_id)
+            nummeraanduiding=nummeraanduiding_obj)
 
 
 def create_hr_data():


### PR DESCRIPTION
* Improved prefetch-related lookups
* Removed `count()` calls in `Verblijfsobject.willekeurig_pand`, and read prefetch cache instead if this is available.
* changed `DataSelectie.bag_numid` to a Django ForeignKey field that still uses the same `db_field`. now Django can prefetch the relation, fixing N-query issues for the "hr" index build