### PR TITLE
BRK dataselectie result fix

### DIFF
--- a/web/dataselectie/datasets/brk/tests/fixture_utils.py
+++ b/web/dataselectie/datasets/brk/tests/fixture_utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import random
 
 import factory
 import faker
@@ -298,6 +299,36 @@ def create_eigendom1():
         )
     ]
 
+def create_eigendommen(number_of_instances: int) -> list:
+    """
+    depends on kadastraal object and categroie fixtures
+    args:
+        number_of_instances: number of objects to create
+    :return: a list of eigendom objects
+    """
+    number_of_instances = number_of_instances + 1
+    create_eigenaar_categorie()
+    kadastraal_objects = [create_kadastraal_object for _ in range(1,number_of_instances) ]
+    kadastraal_subject = [EigenaarFactory.create() for _ in range(1,number_of_instances) ]
+    zakelijkrecht = [ZakelijkRechtFactory.create() for _ in range(1,number_of_instances) ]
+
+    eigendommen = []
+    for kot, zkr, ksb in zip(kadastraal_objects, zakelijkrecht, kadastraal_subject):
+
+        eigendommen.append(
+
+            models.Eigendom.objects.get_or_create(
+                zakelijk_recht=zkr,
+                kadastraal_subject=ksb,
+                kadastraal_object=kot,
+                eigenaar_categorie_id=random.randrange(1, 4, 2),
+                grondeigenaar=False,
+                aanschrijfbaar=False,
+                appartementeigenaar=True,
+            )
+    )
+
+    return eigendommen
 
 def create_eigenaar_categorie():
     return [

--- a/web/dataselectie/datasets/brk/tests/fixture_utils.py
+++ b/web/dataselectie/datasets/brk/tests/fixture_utils.py
@@ -254,7 +254,7 @@ def create_kadastraal_object1():
 
 def create_eigendom():
     """
-    depends on kadastraal object and categroie fixtures
+    depends on kadastraal object and categorie fixtures
     :return: a list of eigendom objects
     """
     create_eigenaar_categorie()
@@ -278,7 +278,7 @@ def create_eigendom():
 
 def create_eigendom1():
     """
-    depends on kadastraal object and categroie fixtures
+    depends on kadastraal object and categorie fixtures
     :return: a list of eigendom objects
     """
     create_eigenaar_categorie()
@@ -301,16 +301,16 @@ def create_eigendom1():
 
 def create_eigendommen(number_of_instances: int) -> list:
     """
-    depends on kadastraal object and categroie fixtures
+    depends on kadastraal object and categorie fixtures
     args:
         number_of_instances: number of objects to create
     :return: a list of eigendom objects
     """
-    number_of_instances = number_of_instances + 1
+    number_of_instances = number_of_instances
     create_eigenaar_categorie()
-    kadastraal_objects = [create_kadastraal_object for _ in range(1,number_of_instances) ]
-    kadastraal_subject = [EigenaarFactory.create() for _ in range(1,number_of_instances) ]
-    zakelijkrecht = [ZakelijkRechtFactory.create() for _ in range(1,number_of_instances) ]
+    kadastraal_objects = [create_kadastraal_object for _ in range(0,number_of_instances) ]
+    kadastraal_subject = [EigenaarFactory.create() for _ in range(0,number_of_instances) ]
+    zakelijkrecht = [ZakelijkRechtFactory.create() for _ in range(0,number_of_instances) ]
 
     eigendommen = []
     for kot, zkr, ksb in zip(kadastraal_objects, zakelijkrecht, kadastraal_subject):

--- a/web/dataselectie/datasets/brk/tests/test_api.py
+++ b/web/dataselectie/datasets/brk/tests/test_api.py
@@ -458,14 +458,6 @@ class FilterApiTestMultipleOutput(ESTestCase, AuthorizationSetup):
 
     @classmethod
     def setUpTestData(cls):
-        # super(ESTestCase, cls).setUpTestData()
-
-        bag.create_gemeente_fixture()
-        bag.create_buurt_combinaties()
-        bag.create_buurt_fixtures()
-        bag.create_gebiedsgericht_werken_fixtures()
-        bag.create_stadsdeel_fixtures()
-
         create_brk_data()
         # create 10 objects in the database
         eigendom = brk.create_eigendommen(10)

--- a/web/dataselectie/datasets/brk/views.py
+++ b/web/dataselectie/datasets/brk/views.py
@@ -289,8 +289,12 @@ class BrkKotSearch(BrkAggBase, TableSearchView):
         # the returned rows must be restricted by the size and page paramaters
         # not before.
         param_size = query['size']
-        offset = (int(self.request_parameters.get('page', 1)) - 1) * param_size
-        param_size = param_size * int(self.request_parameters.get('page', 1)) if offset > 0 else param_size
+        try:
+            param_page = int(self.request_parameters.get('page', 1))
+        except ValueError:
+            param_page = 1
+        offset = (param_page - 1) * param_size
+        size = param_size * param_page if offset > 0 else param_size
 
         # reset orginal param values (the param_size and offset are used now)
         query['size'] = settings.MAX_SEARCH_ITEMS


### PR DESCRIPTION
Currently after the query result, the kadastraal objects are post filtered on uniqueness. Due that multiple addresses can be related to a kadastraal object, the kadastraal object can appear more then once in the result set. To cope with this, kadastraal objects are removed after the query result. However, this causes a mismatch between the size URL parameter and the final result. Hence, the final result can be smaller (due to te removal of objects) then the given size value. This can be confusing for the user.

Now, after the de-duplication of the kadastraal objects, the number of results is finally defined by the given size value. Making the numer of results equal to the size parameter.