### PR TITLE
Bump Django to 2.2.28

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -5,7 +5,7 @@ chardet==3.0.4
 cryptography==3.3.2
 datapunt-authorization-django==1.3.2
 datapunt-authorization-levels==0.1.3
-Django==2.2.27
+Django==2.2.28
 django-cors-headers==3.0.2
 django-filter==2.4.0
 django-jenkins==0.110.0


### PR DESCRIPTION
Bump Django to 2.2.28 because of CVE-2022-28346
https://docs.djangoproject.com/en/4.0/releases/2.2.28/