### PR TITLE
Bump requests, urllib3

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -23,8 +23,8 @@ pycparser==2.19
 PyJWT==2.4.0
 python-dateutil==2.8.1
 pytz==2019.3
-requests==2.25.0
+requests==2.28.2
 sentry-sdk==1.14.0
 six==1.14.0
 text-unidecode==1.3
-urllib3==1.26.5
+urllib3==1.26.15


### PR DESCRIPTION
Fixes dependency clash from #65:

    The user requested urllib3==1.26.5
    elasticsearch 6.4.0 depends on urllib3>=1.21.1
    requests 2.25.0 depends on urllib3<1.27 and >=1.21.1
    sentry-sdk 1.14.0 depends on urllib3>=1.26.11; python_version >= "3.6"