### PR TITLE
Use postgres 12 database image

### DIFF
--- a/.jenkins-test/docker-compose.yml
+++ b/.jenkins-test/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     command: elasticsearch -Ehttp.host=0.0.0.0 -Etransport.host=127.0.0.1
 
   database:
-      image: amsterdam/postgres11
+      image: amsterdam/postgres12
       environment:
           POSTGRES_USER: dataselectie
           POSTGRES_DB: dataselectie

--- a/docker-compose-m1.yml
+++ b/docker-compose-m1.yml
@@ -13,7 +13,7 @@ services:
         - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
 
   database:
-    image: amsterdam/postgres11
+    image: amsterdam/postgres12
     ports:
       - "5435:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
 
   database:
-    image: amsterdam/postgres11
+    image: amsterdam/postgres12
     ports:
       - "5435:5432"
     environment:

--- a/web/.jenkins-import/docker-compose.yml
+++ b/web/.jenkins-import/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     command: elasticsearch -Ehttp.host=0.0.0.0 -Etransport.host=127.0.0.1
 
   database:
-    image: amsterdam/postgres11
+    image: amsterdam/postgres12
     environment:
       POSTGRES_USER: dataselectie
       POSTGRES_DB: dataselectie


### PR DESCRIPTION
The bag dump is created by pg_dump v12, restoring with v11 fails.
Image is already available at amsterdam/postgres12