### PR TITLE
AB#113171 Increase search timeout for elastic searches

### DIFF
--- a/web/dataselectie/dataselectie/settings.py
+++ b/web/dataselectie/dataselectie/settings.py
@@ -105,6 +105,7 @@ ELASTIC_INDICES = {
 }
 
 ELASTIC_INDEXING_TIMEOUT_SECONDS = int(os.getenv('ELASTIC_INDEXING_TIMEOUT_SECONDS', 60))
+ELASTIC_SEARCH_TIMEOUT_SECONDS = os.getenv('ELASTIC_INDEXING_TIMEOUT_SECONDS', "30s")
 
 # MAX_SEARCH_ITEMS is limited by the ElasticSearch index.max_result_window index setting which defaults to 10_000
 MAX_SEARCH_ITEMS = 10000

--- a/web/dataselectie/datasets/generic/views_mixins.py
+++ b/web/dataselectie/datasets/generic/views_mixins.py
@@ -319,7 +319,8 @@ class ElasticSearchMixin(object):
         query = self.add_elastic_filters(q)
         # Performing the search
         response = self.elastic.search(
-            index=settings.ELASTIC_INDICES[self.index], body=query)
+            index=settings.ELASTIC_INDICES[self.index], body=query, 
+            timeout=settings.ELASTIC_SEARCH_TIMEOUT_SECONDS)
         elastic_data = {
             'aggs_list': self.process_aggs(response.get('aggregations', {})),
             'object_list': [item['_source'] for item in


### PR DESCRIPTION
Default timeout is 10 sec. For some searches this is not enough, so increased it to 30 sec.