### PR TITLE
Swap lat/lon for coordinates of adresseerbaar_object

### DIFF
--- a/web/dataselectie/dataselectie/settings.py
+++ b/web/dataselectie/dataselectie/settings.py
@@ -21,6 +21,9 @@ from dataselectie.utils import get_variable
 from dataselectie.utils import get_db_settings
 from pathlib import Path
 
+def str2bool(v):
+    return v.lower() in ("yes", "true", "t", "1")
+
 
 DATAPUNT_API_URL = os.getenv("DATAPUNT_API_URL", "https://api.data.amsterdam.nl/")
 
@@ -106,6 +109,7 @@ ELASTIC_INDICES = {
 
 ELASTIC_INDEXING_TIMEOUT_SECONDS = int(os.getenv('ELASTIC_INDEXING_TIMEOUT_SECONDS', 60))
 ELASTIC_SEARCH_TIMEOUT_SECONDS = os.getenv('ELASTIC_INDEXING_TIMEOUT_SECONDS', "30s")
+ELASTIC_SWAP_LAT_LON_COORDS = str2bool(os.getenv('ELASTIC_SWAP_LAT_LON_COORDS ', 'true'))
 
 # MAX_SEARCH_ITEMS is limited by the ElasticSearch index.max_result_window index setting which defaults to 10_000
 MAX_SEARCH_ITEMS = 10000

--- a/web/dataselectie/datasets/bag/documents.py
+++ b/web/dataselectie/datasets/bag/documents.py
@@ -101,10 +101,14 @@ def update_doc_with_adresseerbaar_object(doc: Nummeraanduiding, item: models.Num
     """
     adresseerbaar_object = item.adresseerbaar_object
 
+    # Seems lat/lon needs to be swapped, could be because of a new
+    # GDAL version.
     try:
-        doc.centroid = (
+        swap = settings.ELASTIC_SWAP_LAT_LON_COORDS 
+        centroid = (
             adresseerbaar_object
             .geometrie.centroid.transform('wgs84', clone=True).coords)
+        doc.centroid = centroid[::-1] if swap else centroid
     except AttributeError:
         batch.statistics.add('BAG Missing geometrie', total=False)
         log.error('Missing geometrie %s' % adresseerbaar_object)


### PR DESCRIPTION
For some reason (maybe GDAL upgrade?) lat/lon are now indexed in the wrong order.