### PR TITLE
Up azure-monitor-opentelemetry to 1.6.7 to fix import error;

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -32,4 +32,4 @@ azure-identity==1.16.1
 uwsgi==2.0.22
 uwsgi-readiness-check==0.2.0
 uwsgitop==0.12
-azure-monitor-opentelemetry==1.5.0
+azure-monitor-opentelemetry==1.6.7


### PR DESCRIPTION
Pod fails with:
```
ImportError: cannot import name 'get_dist_dependency_conflicts' from 'opentelemetry.instrumentation.dependencies'
```
Up the opentelemetry version to fix this bug
For more info see:
https://github.com/Azure/azure-sdk-for-python/issues/40465